### PR TITLE
Fix Linux shutdown hang: wake blocked socket threads in debug-monitor/framebuffer servers

### DIFF
--- a/platforms/shared/desktop/socket_types.h
+++ b/platforms/shared/desktop/socket_types.h
@@ -28,6 +28,7 @@
     typedef int glynx_socket_len_t;
     #define GLYNX_INVALID_SOCKET INVALID_SOCKET
     #define GLYNX_SOCKET_CLOSE(s) closesocket(s)
+    #define GLYNX_SOCKET_SHUTDOWN(s) ::shutdown((s), SD_BOTH)
 #else
     #include <sys/socket.h>
     #include <netinet/in.h>
@@ -39,6 +40,7 @@
     typedef socklen_t glynx_socket_len_t;
     #define GLYNX_INVALID_SOCKET -1
     #define GLYNX_SOCKET_CLOSE(s) ::close(s)
+    #define GLYNX_SOCKET_SHUTDOWN(s) ::shutdown((s), SHUT_RDWR)
 #endif
 
 #endif /* SOCKET_TYPES_H */

--- a/platforms/shared/desktop/vscode/debug_monitor_server.cpp
+++ b/platforms/shared/desktop/vscode/debug_monitor_server.cpp
@@ -132,10 +132,6 @@ void DebugMonitorServer::Stop()
         std::lock_guard<std::mutex> lock(m_client_mutex);
         if (m_client_socket != GLYNX_INVALID_SOCKET)
         {
-            // shutdown() before close() so a thread blocked in recv() on this
-            // socket is woken. On Linux close() alone does not interrupt a
-            // blocking recv()/accept() in another thread, which would wedge the
-            // join() below and leave the process (and its port) alive.
             GLYNX_SOCKET_SHUTDOWN(m_client_socket);
             GLYNX_SOCKET_CLOSE(m_client_socket);
             m_client_socket = GLYNX_INVALID_SOCKET;
@@ -144,8 +140,6 @@ void DebugMonitorServer::Stop()
 
     if (m_server_socket != GLYNX_INVALID_SOCKET)
     {
-        // shutdown() before close() so the AcceptLoop thread blocked in accept()
-        // is woken (see note above).
         GLYNX_SOCKET_SHUTDOWN(m_server_socket);
         GLYNX_SOCKET_CLOSE(m_server_socket);
         m_server_socket = GLYNX_INVALID_SOCKET;

--- a/platforms/shared/desktop/vscode/debug_monitor_server.cpp
+++ b/platforms/shared/desktop/vscode/debug_monitor_server.cpp
@@ -132,6 +132,11 @@ void DebugMonitorServer::Stop()
         std::lock_guard<std::mutex> lock(m_client_mutex);
         if (m_client_socket != GLYNX_INVALID_SOCKET)
         {
+            // shutdown() before close() so a thread blocked in recv() on this
+            // socket is woken. On Linux close() alone does not interrupt a
+            // blocking recv()/accept() in another thread, which would wedge the
+            // join() below and leave the process (and its port) alive.
+            GLYNX_SOCKET_SHUTDOWN(m_client_socket);
             GLYNX_SOCKET_CLOSE(m_client_socket);
             m_client_socket = GLYNX_INVALID_SOCKET;
         }
@@ -139,6 +144,9 @@ void DebugMonitorServer::Stop()
 
     if (m_server_socket != GLYNX_INVALID_SOCKET)
     {
+        // shutdown() before close() so the AcceptLoop thread blocked in accept()
+        // is woken (see note above).
+        GLYNX_SOCKET_SHUTDOWN(m_server_socket);
         GLYNX_SOCKET_CLOSE(m_server_socket);
         m_server_socket = GLYNX_INVALID_SOCKET;
     }

--- a/platforms/shared/desktop/vscode/framebuffer_server.cpp
+++ b/platforms/shared/desktop/vscode/framebuffer_server.cpp
@@ -117,6 +117,11 @@ void FramebufferServer::Stop()
         std::lock_guard<std::mutex> lock(m_client_mutex);
         if (m_client_socket != GLYNX_INVALID_SOCKET)
         {
+            // shutdown() before close() so a thread blocked in recv()/send() on
+            // this socket is woken. On Linux close() alone does not interrupt a
+            // blocking accept()/recv() in another thread, which would wedge the
+            // join() below and leave the process (and its port) alive.
+            GLYNX_SOCKET_SHUTDOWN(m_client_socket);
             GLYNX_SOCKET_CLOSE(m_client_socket);
             m_client_socket = GLYNX_INVALID_SOCKET;
         }
@@ -124,6 +129,9 @@ void FramebufferServer::Stop()
 
     if (m_server_socket != GLYNX_INVALID_SOCKET)
     {
+        // shutdown() before close() so the accept thread blocked in accept() is
+        // woken (see note above).
+        GLYNX_SOCKET_SHUTDOWN(m_server_socket);
         GLYNX_SOCKET_CLOSE(m_server_socket);
         m_server_socket = GLYNX_INVALID_SOCKET;
     }

--- a/platforms/shared/desktop/vscode/framebuffer_server.cpp
+++ b/platforms/shared/desktop/vscode/framebuffer_server.cpp
@@ -117,10 +117,6 @@ void FramebufferServer::Stop()
         std::lock_guard<std::mutex> lock(m_client_mutex);
         if (m_client_socket != GLYNX_INVALID_SOCKET)
         {
-            // shutdown() before close() so a thread blocked in recv()/send() on
-            // this socket is woken. On Linux close() alone does not interrupt a
-            // blocking accept()/recv() in another thread, which would wedge the
-            // join() below and leave the process (and its port) alive.
             GLYNX_SOCKET_SHUTDOWN(m_client_socket);
             GLYNX_SOCKET_CLOSE(m_client_socket);
             m_client_socket = GLYNX_INVALID_SOCKET;
@@ -129,8 +125,6 @@ void FramebufferServer::Stop()
 
     if (m_server_socket != GLYNX_INVALID_SOCKET)
     {
-        // shutdown() before close() so the accept thread blocked in accept() is
-        // woken (see note above).
         GLYNX_SOCKET_SHUTDOWN(m_server_socket);
         GLYNX_SOCKET_CLOSE(m_server_socket);
         m_server_socket = GLYNX_INVALID_SOCKET;


### PR DESCRIPTION
## Problem

On Linux, the Gearlynx process does not exit when the VS Code debugger session ends (e.g. running with `--headless --debug-monitor`). The lingering process keeps the debug-monitor TCP port bound, so the next debug session spawns a new emulator that fails to bind the port.

## Root cause

When the process is asked to shut down, `emu_destroy()` deletes the framebuffer and debug-monitor servers, whose destructors call `Stop()`. `Stop()` sets the running flag false, `close()`s the listening and client sockets, then `join()`s the network threads.

The catch: on Linux, calling `close()` on a socket from one thread does **not** wake another thread that is blocked in `accept()` or `recv()` on that same fd. So:

- `AcceptLoop` stays blocked in `accept(m_server_socket)`
- `RecvLoop` stays blocked in `recv()`

`Stop()` then blocks forever on `join()`, the process never exits, and the port stays bound. On Windows this does not happen because `closesocket()` interrupts blocked `accept()`/`recv()`, which is why the bug is Linux-only.

This affects both `DebugMonitorServer` and `FramebufferServer` (the latter is torn down first in `emu_destroy()`, so it can wedge shutdown before the debug monitor is even reached).

## Fix

Call `shutdown()` before `close()` for both the client and listening sockets in each `Stop()`. On Linux `shutdown(SHUT_RDWR)` wakes the blocked `recv()` (returns 0) and `accept()` (returns an error), so the loops observe the cleared running flag, return, and the joins complete cleanly. A new portable `GLYNX_SOCKET_SHUTDOWN` macro (`SHUT_RDWR` / `SD_BOTH`) is added in `socket_types.h`.

## Notes / caveats

- `shutdown()` reliably wakes `accept()` on Linux. On macOS `shutdown()` on a listening socket can return `ENOTCONN` and not wake `accept()`; a fully portable approach would use non-blocking sockets with `poll()`/timeouts or a self-pipe. This PR targets the reported Linux hang with a minimal change; Windows is already unaffected.

## Testing

- [ ] Built and run on Linux: start with `--headless --debug-monitor`, connect/disconnect a debug client, send SIGTERM, confirm the process exits and the port is released.
